### PR TITLE
Added additional logic for reconcile

### DIFF
--- a/config/samples/webapp_v1_partitionjob.yaml
+++ b/config/samples/webapp_v1_partitionjob.yaml
@@ -9,4 +9,12 @@ metadata:
     app.kubernetes.io/created-by: partitionjob
   name: partitionjob-sample
 spec:
-  # TODO(user): Add fields here
+  partitions: 1
+  selector:
+    matchLabels:
+      app: for-partition
+  template:
+    spec:
+      containers:
+        - name: nginx-container
+          image: nginx-alpine


### PR DESCRIPTION
- retrieves the partitionJob object and tries to parse it, if successful, saves it to the PartitionJobReconciler struct 
- to populate the replicas field, lists all the pods in the cluster then filters based on the desired label
- if request cannot be parsed as a partition job resource, attempts to parse as a pod because we are watching for pods
- filters those pods based on the desired labels as well

TODO:
- loop through pods based on our desired number of partitions and update pods accordingly