### PR TITLE
updates to controller

### DIFF
--- a/api/v1/partitionjob_types.go
+++ b/api/v1/partitionjob_types.go
@@ -55,12 +55,11 @@ type PartitionJobStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 
+	// replicas is the number of desired Pods as per PartitionJob controller spec
+	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,4,opt,name=replicas"`
+
 	// currentReplicas is the number of Pods currently observed by the PartitionJob controller
 	CurrentReplicas int32 `json:"currentReplicas,omitempty" protobuf:"varint,4,opt,name=currentReplicas"`
-
-	// updatedReplicas is the number of Pods updated by the PartitionJob controller
-	// +optional
-	UpdatedReplicas int32 `json:"updatedReplicas,omitempty" protobuf:"varint,5,opt,name=updatedReplicas"`
 
 	// currentRevision, if not empty, indicates the version of the PartitionJob used to generate Pods in the
 	// sequence [0,currentReplicas).

--- a/config/crd/bases/webapp.my.domain_partitionjobs.yaml
+++ b/config/crd/bases/webapp.my.domain_partitionjobs.yaml
@@ -7493,15 +7493,15 @@ spec:
                   which is updated on mutation by the API Server.
                 format: int64
                 type: integer
+              replicas:
+                description: replicas is the number of desired Pods as per PartitionJob
+                  controller spec
+                format: int32
+                type: integer
               updateRevision:
                 description: updateRevision, if not empty, indicates the version of
                   the PartitionJob used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
                 type: string
-              updatedReplicas:
-                description: updatedReplicas is the number of Pods updated by the
-                  PartitionJob controller
-                format: int32
-                type: integer
             type: object
         type: object
     served: true

--- a/config/samples/webapp_v1_partitionjob.yaml
+++ b/config/samples/webapp_v1_partitionjob.yaml
@@ -9,13 +9,13 @@ metadata:
     app.kubernetes.io/created-by: partitionjob
   name: partitionjob-sample
 spec:
-  replicas: 6
+  replicas: 5
   partitions: 1
   selector:
     matchLabels:
-      app: for-partition
+      app: partitionjob-sample
   template:
     spec:
       containers:
         - name: nginx-container
-          image: nginx-alpine
+          image: nginx:stable


### PR DESCRIPTION
- re-introduced replicas field as the desired state and removed updatedReplicas
- Removed hard-coding from controller and made it so that all the information is coming from partitionJob CR
- Updated status to include both replicas and currentReplicas as the desired state and observed state respectively